### PR TITLE
Add staticPublishPath to render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,3 +2,4 @@ services:
 - type: web
   name: repository
   env: static
+  staticPublishPath: .


### PR DESCRIPTION
Render requires a `staticPublishPath` to be set for static sites. This is the path from which static files are served. For sites that don't have a build process, it should be set to `.` (project root).